### PR TITLE
fix launch errors by generating empty sqlite dictionary file

### DIFF
--- a/dictdb.py
+++ b/dictdb.py
@@ -8,13 +8,23 @@ import re
 import json
 addon_path = os.path.dirname(__file__)
 from aqt import mw
+from .init_db import initialize_sqlite_file
 
 class DictDB:
     conn = None
     c = None
 
     def __init__(self):
-        db_file = os.path.join(mw.pm.addonFolder(), addon_path, "user_files", "db", "dictionaries.sqlite")
+        db_dir = os.path.join(addon_path, "user_files", "db")
+        os.makedirs(db_dir, exist_ok=True)
+        db_file = os.path.join(db_dir, "dictionaries.sqlite")
+        
+        # create dictionary file if it doesn't exist
+        if not os.path.exists(db_file):
+            f = open(db_file, 'x')
+            f.close()
+            initialize_sqlite_file(db_file)
+                
         self.conn=sqlite3.connect(db_file, check_same_thread=False)
         self.c = self.conn.cursor()
         self.c.execute("PRAGMA foreign_keys = ON")

--- a/dictionaryWebInstallWizard.py
+++ b/dictionaryWebInstallWizard.py
@@ -521,7 +521,7 @@ class DictionaryInstallPage(MiWizardPage):
 
 
     def add_log(self, txt):
-        self.log_box.moveCursor(QTextCursor.End)
+        self.log_box.moveCursor(QTextCursor.MoveOperation.End)
         if not self.log_box.document().isEmpty():
             self.log_box.insertPlainText('\n')    
         self.log_box.insertPlainText(txt)

--- a/init_db.py
+++ b/init_db.py
@@ -1,0 +1,60 @@
+import sqlite3
+import os
+
+    
+def initialize_sqlite_file(db_file:str):
+    # Set up the database path
+    # addon_path = os.path.dirname(__file__)
+    # db_dir = os.path.join(addon_path, "user_files", "db")
+    # os.makedirs(db_dir, exist_ok=True)
+    # db_file = os.path.join(db_dir, "dictionaries.sqlite")
+
+    # Connect to the database
+    conn = sqlite3.connect(db_file)
+    c = conn.cursor()
+
+    # Create langnames table
+    c.execute("""
+    CREATE TABLE IF NOT EXISTS langnames (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        langname TEXT UNIQUE NOT NULL
+    );
+    """)
+
+    # Create dictnames table
+    c.execute("""
+    CREATE TABLE IF NOT EXISTS dictnames (
+        dictname TEXT UNIQUE NOT NULL,
+        lid INTEGER NOT NULL,
+        fields TEXT,
+        addtype TEXT,
+        termHeader TEXT,
+        duplicateHeader INTEGER,
+        FOREIGN KEY (lid) REFERENCES langnames(id)
+    );
+    """)
+
+    # Create a sample dictionary table
+    dict_table = "l1nameSampleDictionary"
+    c.execute(f"""
+    CREATE TABLE IF NOT EXISTS {dict_table} (
+        term CHAR(40) NOT NULL,
+        altterm CHAR(40),
+        pronunciation CHAR(100),
+        pos CHAR(40),
+        definition TEXT,
+        examples TEXT,
+        audio TEXT,
+        frequency MEDIUMINT,
+        starCount TEXT
+    );
+    """)
+    c.execute(f"CREATE INDEX IF NOT EXISTS it{dict_table} ON {dict_table} (term);")
+    c.execute(f"CREATE INDEX IF NOT EXISTS itp{dict_table} ON {dict_table} (term, pronunciation);")
+    c.execute(f"CREATE INDEX IF NOT EXISTS ia{dict_table} ON {dict_table} (altterm);")
+    c.execute(f"CREATE INDEX IF NOT EXISTS iap{dict_table} ON {dict_table} (altterm, pronunciation);")
+    c.execute(f"CREATE INDEX IF NOT EXISTS ia{dict_table}_pron ON {dict_table} (pronunciation);")
+
+    # Commit and close
+    conn.commit()
+    conn.close()

--- a/main.py
+++ b/main.py
@@ -111,7 +111,6 @@ def showA(ar):
 dictWidget  = False
 
 js = QFile(':/qtwebchannel/qwebchannel.js')
-assert js.open(QIODevice.ReadOnly)
 js = bytes(js.readAll()).decode('utf-8')
 
 

--- a/midict.py
+++ b/midict.py
@@ -46,6 +46,7 @@ from .themes import *
 class MIDict(AnkiWebView):
     def __init__(self, dictInt, db, path, terms=False):
         AnkiWebView.__init__(self)
+        self._page = self.page() # renaming variable for porting
         self._page.profile().setHttpUserAgent(
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36')
         self.terms = terms


### PR DESCRIPTION
Closes Issue #7 

The main issue is that `dictionaries.sqlite` doesn't exist upon installing the addon, since user_files are only included as empty directories. An alternative would be to upload a template database file to the github, so we wouldn't need to generate one on launch.

Also fixed small bugs related to older versions of some addons.